### PR TITLE
fix: createdAt과 updatedAt이 자동 입력되지 않던 문제 해결

### DIFF
--- a/src/main/java/GreenSpark/greenspark/GreensparkApplication.java
+++ b/src/main/java/GreenSpark/greenspark/GreensparkApplication.java
@@ -2,10 +2,11 @@ package GreenSpark.greenspark;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class GreensparkApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(GreensparkApplication.class, args);
 	}


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #6 

## 📝작업 내용

> baseEntity의 createdAt과 updatedAt이 생성시에 자동으로 db에 저장되지 않는 문제를 발견해 해결함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
