### PR TITLE
feat: 작년과의 비교 그래프 API 구현

### DIFF
--- a/src/main/java/GreenSpark/greenspark/controller/PowerController.java
+++ b/src/main/java/GreenSpark/greenspark/controller/PowerController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RequestMapping("/api")
 @RequiredArgsConstructor
 @RestController
@@ -27,5 +29,13 @@ public class PowerController {
         PowerResponseDto.PowerCreateResponseDto responseDto = PowerConverter.toPowerCreateResponseDto(createdUserId);
 
         return DataResponseDto.of(responseDto, "전력 입력을 완료했습니다.");
+    }
+
+    @GetMapping(value = "/power/{userId}")
+    public DataResponseDto<List<PowerResponseDto.PowerGetDataResponseDto>> getPowerData(
+            @PathVariable Long userId,
+            @RequestParam(name = "display") String display){
+        List<PowerResponseDto.PowerGetDataResponseDto> powerDataList = powerService.getPowerData(userId, display);
+        return DataResponseDto.of(powerDataList, "해당 유저의 전기요금 또는 전력사용량을 조회했습니다.");
     }
 }

--- a/src/main/java/GreenSpark/greenspark/dto/PowerRequestDto.java
+++ b/src/main/java/GreenSpark/greenspark/dto/PowerRequestDto.java
@@ -11,7 +11,6 @@ import java.time.YearMonth;
 
 public class PowerRequestDto {
 
-    @ToString
     @Getter
     @Setter
     public static class PowerCreateRequestDto{
@@ -23,6 +22,5 @@ public class PowerRequestDto {
         private int cost;
         @NotNull
         private int usageAmount;
-
     }
 }

--- a/src/main/java/GreenSpark/greenspark/dto/PowerResponseDto.java
+++ b/src/main/java/GreenSpark/greenspark/dto/PowerResponseDto.java
@@ -1,10 +1,9 @@
 package GreenSpark.greenspark.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.util.List;
 
 public class PowerResponseDto {
     @Builder
@@ -14,5 +13,15 @@ public class PowerResponseDto {
     public static class PowerCreateResponseDto {
         @JsonProperty("user_id")
         Long userId;
+    }
+
+    @Builder
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class PowerGetDataResponseDto {
+        private int year;
+        private int month;
+        private int value;
     }
 }

--- a/src/main/java/GreenSpark/greenspark/repository/PowerRepository.java
+++ b/src/main/java/GreenSpark/greenspark/repository/PowerRepository.java
@@ -1,7 +1,13 @@
 package GreenSpark.greenspark.repository;
 
 import GreenSpark.greenspark.domain.Power;
+import GreenSpark.greenspark.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface PowerRepository extends JpaRepository<Power, Long> {
+    Optional<Power> findByYearAndMonthAndUser(int year, int month, User user);
+    List<Power> findAllByUserAndYearBetweenAndMonthBetween(User user, int startYear, int endYear, int startMonth, int endMonth);
 }

--- a/src/main/java/GreenSpark/greenspark/service/PowerService.java
+++ b/src/main/java/GreenSpark/greenspark/service/PowerService.java
@@ -4,11 +4,17 @@ import GreenSpark.greenspark.converter.PowerConverter;
 import GreenSpark.greenspark.domain.Power;
 import GreenSpark.greenspark.domain.User;
 import GreenSpark.greenspark.dto.PowerRequestDto;
+import GreenSpark.greenspark.dto.PowerResponseDto;
 import GreenSpark.greenspark.repository.PowerRepository;
 import GreenSpark.greenspark.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -20,8 +26,47 @@ public class PowerService {
     public Power createPower(Long userId, PowerRequestDto.PowerCreateRequestDto powerCreateRequestDto) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
-        Power power = PowerConverter.toPower(user, powerCreateRequestDto);
+
+        int year = powerCreateRequestDto.getYear();
+        int month = powerCreateRequestDto.getMonth();
+        Optional<Power> existingPower = powerRepository.findByYearAndMonthAndUser(year, month, user);
+
+        Power power;
+        if (existingPower.isPresent()) { // 기존 데이터가 있을 경우 업데이트
+            power = existingPower.get();
+            power.setCost(powerCreateRequestDto.getCost());
+            power.setUsageAmount(powerCreateRequestDto.getUsageAmount());
+        } else { // 기존 데이터가 없을 경우 새로 생성
+            power = PowerConverter.toPower(user, powerCreateRequestDto);
+        }
 
         return powerRepository.save(power);
+    }
+
+    public List<PowerResponseDto.PowerGetDataResponseDto> getPowerData(Long userId, String display) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        LocalDate now = LocalDate.now();
+        int currentYear = now.getYear();
+        int currentMonth = now.getMonthValue();
+
+        List<Power> powers = powerRepository.findAllByUserAndYearBetweenAndMonthBetween(
+                user,
+                currentYear - 1, currentYear, // 작년과 올해
+                1, currentMonth // 1월 ~ 이번 달
+        );
+
+        if ("bill".equalsIgnoreCase(display)) {
+            return powers.stream()
+                    .map(power -> new PowerResponseDto.PowerGetDataResponseDto(power.getYear(), power.getMonth(), power.getCost()))
+                    .collect(Collectors.toList());
+        } else if ("usage".equalsIgnoreCase(display)) {
+            return powers.stream()
+                    .map(power -> new PowerResponseDto.PowerGetDataResponseDto(power.getYear(), power.getMonth(), power.getUsageAmount()))
+                    .collect(Collectors.toList());
+        } else {
+            throw new IllegalArgumentException("알맞은 display 문자열이 아닙니다.: " + display);
+        }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #8 

## 📝작업 내용

>  전력 입력 API 같은 연도, 달에 입력 시 업데이트 하도록 수정
> 작년과 비교 그래프에 필요한 전기요금 또는 전력사용량을 쿼리 파라미터에 따라 구분해 조회하는 API 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
