### PR TITLE
feat: 매년 1월 1일에 3년 전 Power DB 데이터 삭제 로직 추가

### DIFF
--- a/src/main/java/GreenSpark/greenspark/repository/PowerRepository.java
+++ b/src/main/java/GreenSpark/greenspark/repository/PowerRepository.java
@@ -3,6 +3,9 @@ package GreenSpark.greenspark.repository;
 import GreenSpark.greenspark.domain.Power;
 import GreenSpark.greenspark.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +15,8 @@ public interface PowerRepository extends JpaRepository<Power, Long> {
     List<Power> findAllByUserAndYearBetweenAndMonthBetween(User user, int startYear, int endYear, int startMonth, int endMonth);
     List<Power> findByUser(User user);
     Optional<Power> findByUserAndYearAndMonth(User user, int year, int month);
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM Power p WHERE p.year <= :thresholdYear")
+    void deleteByYearLessThanEqual(int thresholdYear);
 }

--- a/src/main/java/GreenSpark/greenspark/service/PowerService.java
+++ b/src/main/java/GreenSpark/greenspark/service/PowerService.java
@@ -9,6 +9,7 @@ import GreenSpark.greenspark.repository.PowerRepository;
 import GreenSpark.greenspark.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -142,5 +143,13 @@ public class PowerService {
         int monthBeforeLastCost = monthBeforeLastPower.getCost();
 
         return PowerConverter.toPowerGetLastMonthPowerResponseDto(lastMonthCost, monthBeforeLastCost);
+    }
+
+    // 매년 1월 1일 00:00에 실행되도록 스케줄링 설정
+    @Scheduled(cron = "0 0 0 1 1 *")
+    public void deleteOldRecordsOnNewYear() {
+        int thresholdYear = LocalDate.now().getYear() - 3;
+        powerRepository.deleteByYearLessThanEqual(thresholdYear);
+        System.out.println("3년 이상 지난 데이터가 삭제되었습니다.");
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #33 

## 📝작업 내용

> 스프링 @Scheduled를 이용해 매년 1월 1일에 3년 전 Power DB 데이터 삭제하는 로직을 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
