### PR TITLE
feat: 이번달 예상 요금 API 구현

### DIFF
--- a/src/main/java/GreenSpark/greenspark/controller/PowerController.java
+++ b/src/main/java/GreenSpark/greenspark/controller/PowerController.java
@@ -75,4 +75,11 @@ public class PowerController {
         PowerResponseDto.PowerGetLastMonthPowerResponseDto lastMonthList = powerService.getLastMonthPower(userId);
         return DataResponseDto.of(lastMonthList, "해당 유저의 저번달 요금과 저저번달 요금을 조회했습니다.");
     }
+
+    @GetMapping(value = "/power/expect/{userId}")
+    public DataResponseDto<PowerResponseDto.PowerGetExpectedCostResponseDto> getExpectedCost(
+            @PathVariable Long userId){
+        PowerResponseDto.PowerGetExpectedCostResponseDto lastMonthList = powerService.getExpectedCost(userId);
+        return DataResponseDto.of(lastMonthList, "해당 유저의 예상 요금과 저번달 요금을 조회했습니다.");
+    }
 }

--- a/src/main/java/GreenSpark/greenspark/converter/PowerConverter.java
+++ b/src/main/java/GreenSpark/greenspark/converter/PowerConverter.java
@@ -50,4 +50,11 @@ public class PowerConverter {
                 .monthBeforeLastCost(monthBeforeLastCost)
                 .build();
     }
+
+    public static PowerResponseDto.PowerGetExpectedCostResponseDto toGetExpectedCostResponseDto(int expectedCost, int lastMonthCost){
+        return PowerResponseDto.PowerGetExpectedCostResponseDto.builder()
+                .expectedCost(expectedCost)
+                .lastMonthCost(lastMonthCost)
+                .build();
+    }
 }

--- a/src/main/java/GreenSpark/greenspark/dto/PowerRequestDto.java
+++ b/src/main/java/GreenSpark/greenspark/dto/PowerRequestDto.java
@@ -1,12 +1,12 @@
 package GreenSpark.greenspark.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.LocalDate;
 import java.time.YearMonth;
 
 public class PowerRequestDto {
@@ -42,5 +42,14 @@ public class PowerRequestDto {
         private int month;
         @NotNull
         private int usageAmount;
+    }
+
+    @Builder
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class PowerGetExpectedCostRequestToFastAPIDto {
+        private String  date;
+        private int cost;
     }
 }

--- a/src/main/java/GreenSpark/greenspark/dto/PowerResponseDto.java
+++ b/src/main/java/GreenSpark/greenspark/dto/PowerResponseDto.java
@@ -47,4 +47,15 @@ public class PowerResponseDto {
         @JsonProperty("month_before_last_cost")
         private int monthBeforeLastCost;
     }
+
+    @Builder
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class PowerGetExpectedCostResponseDto {
+        @JsonProperty("expected_cost")
+        private int expectedCost;
+        @JsonProperty("last_month_cost")
+        private int lastMonthCost;
+    }
 }

--- a/src/main/java/GreenSpark/greenspark/repository/PowerRepository.java
+++ b/src/main/java/GreenSpark/greenspark/repository/PowerRepository.java
@@ -19,4 +19,5 @@ public interface PowerRepository extends JpaRepository<Power, Long> {
     @Transactional
     @Query("DELETE FROM Power p WHERE p.year <= :thresholdYear")
     void deleteByYearLessThanEqual(int thresholdYear);
+    List<Power> findAllByUser(User user);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ api:
   service-key: ${API_SERVICE_KEY}
 spring:
   datasource:
-    url: ${DB_URL}
+    url: jdbc:mysql://greenspark-db.cpeammio2vo7.ap-northeast-2.rds.amazonaws.com:3306/greenspark_db
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #36 

## 📝작업 내용

> 이번달 예상 요금 API 구현
> greenspark-backend-fastAPI와 통신하여 유저의 요금과 달 정보를 건내주고 예상 요금을 받아오는 로직 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
