### PR TITLE
feat: 파워 그래프 조회 API의 전기요금 조회 시 예상 요금 추가

### DIFF
--- a/src/main/java/GreenSpark/greenspark/controller/PowerController.java
+++ b/src/main/java/GreenSpark/greenspark/controller/PowerController.java
@@ -57,6 +57,20 @@ public class PowerController {
         return DataResponseDto.of(powerList, "해당 유저의 모든 파워 정보를 조회했습니다.");
     }
 
+    @GetMapping(value = "/power/last-month/{userId}")
+    public DataResponseDto<PowerResponseDto.PowerGetLastMonthPowerResponseDto> getLastMonthPower(
+            @PathVariable Long userId){
+        PowerResponseDto.PowerGetLastMonthPowerResponseDto lastMonthResponse = powerService.getLastMonthPower(userId);
+        return DataResponseDto.of(lastMonthResponse, "해당 유저의 저번달 요금과 저저번달 요금을 조회했습니다.");
+    }
+
+    @GetMapping(value = "/power/expect/{userId}")
+    public DataResponseDto<PowerResponseDto.PowerGetExpectedCostResponseDto> getExpectedCost(
+            @PathVariable Long userId){
+        PowerResponseDto.PowerGetExpectedCostResponseDto expectedCostResponse = powerService.getExpectedCost(userId);
+        return DataResponseDto.of(expectedCostResponse, "해당 유저의 예상 요금과 저번달 요금을 조회했습니다.");
+    }
+
     // 전기요금, 전력사용량 2개 한 번에 입력받는 API(사용하지 않음)
     @PostMapping(value = "/power/{userId}")
     public DataResponseDto<PowerResponseDto.PowerCreateResponseDto> createPower(
@@ -67,19 +81,5 @@ public class PowerController {
         PowerResponseDto.PowerCreateResponseDto responseDto = PowerConverter.toPowerCreateResponseDto(createdUserId);
 
         return DataResponseDto.of(responseDto, "전력 입력을 완료했습니다.");
-    }
-
-    @GetMapping(value = "/power/last-month/{userId}")
-    public DataResponseDto<PowerResponseDto.PowerGetLastMonthPowerResponseDto> getLastMonthPower(
-            @PathVariable Long userId){
-        PowerResponseDto.PowerGetLastMonthPowerResponseDto lastMonthList = powerService.getLastMonthPower(userId);
-        return DataResponseDto.of(lastMonthList, "해당 유저의 저번달 요금과 저저번달 요금을 조회했습니다.");
-    }
-
-    @GetMapping(value = "/power/expect/{userId}")
-    public DataResponseDto<PowerResponseDto.PowerGetExpectedCostResponseDto> getExpectedCost(
-            @PathVariable Long userId){
-        PowerResponseDto.PowerGetExpectedCostResponseDto lastMonthList = powerService.getExpectedCost(userId);
-        return DataResponseDto.of(lastMonthList, "해당 유저의 예상 요금과 저번달 요금을 조회했습니다.");
     }
 }

--- a/src/main/java/GreenSpark/greenspark/service/PowerService.java
+++ b/src/main/java/GreenSpark/greenspark/service/PowerService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -81,9 +82,20 @@ public class PowerService {
         );
 
         if ("bill".equalsIgnoreCase(display)) {
-            return powers.stream()
+            PowerResponseDto.PowerGetExpectedCostResponseDto expectedCostResponse = getExpectedCost(userId);
+            int expectedCost = expectedCostResponse.getExpectedCost();
+
+            List<PowerResponseDto.PowerGetDataResponseDto> billList =  powers.stream()
                     .map(power -> new PowerResponseDto.PowerGetDataResponseDto(power.getYear(), power.getMonth(), power.getCost()))
-                    .collect(Collectors.toList());
+                    .toList();
+
+            PowerResponseDto.PowerGetDataResponseDto currentData =
+                    new PowerResponseDto.PowerGetDataResponseDto(currentYear, currentMonth, expectedCost);
+
+            List<PowerResponseDto.PowerGetDataResponseDto> updatedBillList = new ArrayList<>(billList);
+            updatedBillList.add(currentData);
+
+            return updatedBillList;
         } else if ("usage".equalsIgnoreCase(display)) {
             return powers.stream()
                     .map(power -> new PowerResponseDto.PowerGetDataResponseDto(power.getYear(), power.getMonth(), power.getUsageAmount()))


### PR DESCRIPTION
## #️⃣연관된 이슈
issue #38 

## 📝작업 내용

> 파워 그래프 조회 API의 전기요금 조회 시 (display = bill)
> 이번 년도, 이번 달, 예상 요금 을 포함하는 집합이 기존 조회된 데이터 리스트에 추가적으로 포함되도록 했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
